### PR TITLE
Add Like System to Collections

### DIFF
--- a/app/(client)/collections/all/page.tsx
+++ b/app/(client)/collections/all/page.tsx
@@ -3,8 +3,10 @@ import { useEffect, useState } from 'react';
 import React from 'react';
 import PageTitle from "@/components/PageTitle";
 import FetchAllCollectionsService from '@/services/FetchAllCollectionsService';
+import FetchUserFavoriteCollectionsService from '@/services/FetchUserFavoriteCollectionsService';
 import { CollectionType as OriginalCollectionType, GoalType } from "@/types/types";
 import { useAuth } from '@clerk/nextjs';
+
 
 interface CollectionType extends OriginalCollectionType {
   accomplishedGoals?: number;
@@ -19,6 +21,25 @@ const collections =  () => {
   const [isLoading, setIsLoading] = useState(true);
   const [isFiltered, setIsFiltered] = useState(false);
   const { userId } = useAuth();
+  const [likedCollections, setLikedCollections] = useState<string[]>([]);
+  
+  useEffect(() => {
+    const fetchLikedCollections = async () => {
+      if (!userId) return;
+
+      // const response = await fetch(`/api/user/${userId}/likedCollections`);
+      // const data = await response.json();
+      const data = await FetchUserFavoriteCollectionsService(userId);
+      console.log("Liked collections:", data);
+
+      // extraire uniquement les collectionId
+      const likedIds = data.data.map((like: { collectionId: string }) => like.collectionId);
+      setLikedCollections(likedIds);
+    };
+
+    fetchLikedCollections();
+  }, [userId]);
+
 
   useEffect(() => {
     const fetchData = async () => {
@@ -27,11 +48,11 @@ const collections =  () => {
       console.log("API response", data);
 
       //  filtre les collections pour retirer celles de l'user connecté 
-       const filteredCollections = data.data.filter((collection: CollectionType) => 
-        collection.userId !== userId
+      // const filteredCollections = data.data.filter((collection: CollectionType) => 
+      // collection.userId !== userId
+      // );
 
-      );
-     setCollections(filteredCollections);
+     setCollections(data.data);
      setIsLoading(false);
      setIsFiltered(true); 
 
@@ -48,6 +69,29 @@ const collections =  () => {
         collection.goals?.filter((goal: GoalType) => goal.isAccomplished).length || 0,
   })) || [];
 
+
+  async function handleLike(collectionId: string) {
+    const response = await fetch('/api/collections/all', {
+      method: 'POST', 
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        userId: userId,
+        collectionId: collectionId,
+      }),
+    });
+
+    const data = await response.json();
+    console.log(data);
+    // Mise à jour locale de l'état pour éviter le refresh
+    setLikedCollections((prevLiked) =>
+      prevLiked.includes(collectionId)
+        ? prevLiked.filter((id) => id !== collectionId) // Retirer si déjà liké
+        : [...prevLiked, collectionId] // ajouter si c'est pas le cas
+    );
+  }
+
   return (
     <>
       <PageTitle title='All collections' />
@@ -61,7 +105,10 @@ const collections =  () => {
                 <p>
                   - {collection.label} by {collection.user.username} | {collection.accomplishedGoals} / {collection.totalGoals}
                 </p>
-                <button>♥</button>
+                <button onClick={() => handleLike(collection.id)}>
+                {likedCollections.includes(collection.id) ? "♥" : "x"}
+              </button>
+                {/* <p>is liked ? </p> */}
               </div>
             ))}
           </div>

--- a/app/api/collections/all/route.ts
+++ b/app/api/collections/all/route.ts
@@ -1,20 +1,37 @@
 import { db } from "@/lib/db";
 import { NextResponse, NextRequest } from "next/server";
 import { clerkClient } from '@clerk/nextjs/server';
+import { getAuth } from "@clerk/nextjs/server";
 
-export async function GET() {
+
+export async function GET(req: NextRequest) {
+
     try {
+
+    const auth = getAuth(req);
+    console.log("Auth data:", auth);
+
+    const { userId } =auth;
+ 
+    if (!userId) {
+      return new Response(JSON.stringify({ error: "Unauthorized" }), { status: 401 });
+    }
+
+    console.log("Utilisateur connecté avec ID:", userId);
 
         const collections = await db.collection.findMany({
             where: {
-                isPrivate: false, // Filtrer les collections publiques
+                isPrivate: false, // Filtrer les collections 
+                userId: { not: userId }
               },
             orderBy: { 
                 createdAt: "desc" 
             },
             include: {
-                goals : true
+                goals : true,
+                likes : true
             }
+            
         });
 
 
@@ -39,13 +56,13 @@ export async function GET() {
             })
         );
         console.log("collections all", collections )
+        console.log("userid co" , userId)
         return NextResponse.json({
             data: collectionWithUser, //null si erreur
-            message: "Succesfully got the collections", // msg d'erreur si erreur
+            message: "Succesfully got all users the collections ", // msg d'erreur si erreur
             success: true, // false si erreur 
         })
 
-        
 
     } catch (error) {
         console.log("[collections]", error)
@@ -57,3 +74,53 @@ export async function GET() {
         )
     }
 }
+
+export async function POST(req: NextRequest) {
+    try {
+      const { userId, collectionId } = await req.json();
+  
+      const existingLike = await db.like.findUnique({
+        where: {
+          userId_collectionId: {
+            userId,
+            collectionId
+          }
+        }
+      });
+  
+      if (existingLike) {
+        await db.like.delete({
+          where: {
+            userId_collectionId: {
+              userId,
+              collectionId
+            }
+          }
+        });
+  
+        return NextResponse.json({
+          success: true,
+          message: "Like removed successfully!" 
+        });
+      }
+  
+      await db.like.create({
+        data: {
+          userId,
+          collectionId,
+        }
+      });
+  
+      return NextResponse.json({
+        success: true,
+        message: "Like added successfully!"
+      });
+  
+    } catch (error) {
+      console.log("[Error handling like]", error);
+      return NextResponse.json({
+        success: false,
+        message: "An error occurred while handling the like."
+      }, { status: 500 });
+    }
+  }

--- a/app/api/user/[userId]/likedCollections/route.ts
+++ b/app/api/user/[userId]/likedCollections/route.ts
@@ -1,0 +1,42 @@
+import { db } from "@/lib/db";
+import { NextRequest, NextResponse } from "next/server";
+
+type Props = {
+  params: Promise<{ userId: string }>;
+};
+
+export async function GET(request: NextRequest, { params }: Props) {
+  try {
+    const { userId } = await params;
+
+    if (!userId) {
+      return NextResponse.json({
+        success: false,
+        message: "User ID is required.",
+      });
+    }
+
+    const likedCollections = await db.like.findMany({
+      where: {
+        userId,
+      },
+    });
+
+    console.log("liked collections", likedCollections);
+
+    return NextResponse.json({
+      data: likedCollections,
+      message: "Successfully fetched user liked collections.",
+      success: true,
+    });
+  } catch (error) {
+    console.log("[likedCollections API error]", error);
+    return NextResponse.json(
+      {
+        success: false,
+        message: "An error occurred while fetching liked collections.",
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/prisma/schema/collection.prisma
+++ b/prisma/schema/collection.prisma
@@ -7,4 +7,5 @@ model Collection {
     userId     String 
 
     goals Goal[]
+    likes Like[] 
 }

--- a/prisma/schema/like.prisma
+++ b/prisma/schema/like.prisma
@@ -1,0 +1,10 @@
+model Like {
+  id          String   @id @default(auto()) @map("_id") @db.ObjectId
+  userId      String   
+  collectionId String @db.ObjectId
+  createdAt   DateTime @default(now())  
+
+  collection  Collection @relation(fields: [collectionId], references: [id], onUpdate: Cascade, onDelete: Cascade)
+  @@unique([userId, collectionId])
+
+}

--- a/services/FetchUserFavoriteCollectionsService.ts
+++ b/services/FetchUserFavoriteCollectionsService.ts
@@ -1,0 +1,17 @@
+const FetchUserFavoriteCollectionsService = async (userId: string | null) => {
+    if (!userId) throw new Error("User ID is required");
+    try {
+        const response =await fetch(`/api/user/${userId}/likedCollections`, {cache: 'force-cache'});
+        if (!response.ok) {
+          throw new Error(`HTTP error! status: ${response.status}`);
+        }
+
+        const data = await response.json();
+        return data;
+      } catch (error) {
+        console.error("Error when fetching the user favorites collections:", error);
+      }
+}
+
+export default FetchUserFavoriteCollectionsService;
+

--- a/types/types.ts
+++ b/types/types.ts
@@ -26,3 +26,10 @@ export interface CategoryType {
     label: string;
     goals: GoalType[];
 }
+
+export interface LikeType {
+    id: string;
+    createdAd : Date;
+    userId : string;
+    collectionId : string;
+}


### PR DESCRIPTION
- Added the ability for users to like or unlike collections.
- Implemented a new Prisma model for likes.
- Created an API route  and a service to fetch collections liked by the user.
- Added a POST method for adding and removing likes.
- Added a service to retrieve public collections from all users (excluding the logged-in user).
- Implemented a visual indicator to show if a collection is already liked by the user (different icon).